### PR TITLE
feat(organims): change column structure

### DIFF
--- a/app/templates/3_organisms/index.jade
+++ b/app/templates/3_organisms/index.jade
@@ -2,10 +2,10 @@ extends ../0_basics/_default
 block content
   .container
     .row
-      .col-lg-12
+      .col-xs-12
         h1 Organisms
         hr
     .row
-      .col-lg-12
+      .col-xs-12
         //- [injector:jadelinks]
         //- [endinjector]


### PR DESCRIPTION
col-lg-12 only supports the large breakview. From my point of view it is better to define the mobile context first. If the content is too small it could happen that it breaks because when it's not in the large breakview.