### PR TITLE
fixed naming bug in readme doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Create a Release of the Project (bump and tag).
 |   ├── □ 2_molecules                     # Folder for Molecules
 |   ├── □ 3_organisms                     # Folder for Organisms
 |   ├── □ 4_templates                     # Folder for Templates
-|   └── □ 5_templates                     # Folder for Templates
+|   └── □ 5_pages                         # Folder for Pages
 ```
 
 ### Module Directory Layout


### PR DESCRIPTION
I thought twice "templates" can not be right, so I replaced point 5 with pages.
I hope it's correct :)